### PR TITLE
format + fix unit conversion in dow-msft case study docs

### DIFF
--- a/use-case-submissions/dow-msft-Graph-DB.md
+++ b/use-case-submissions/dow-msft-Graph-DB.md
@@ -37,16 +37,19 @@ For this case study, we have considered R to be per API call with 32,000 calls o
 Energy was used by measuring CPU and memory utilization and using a model of Thermal Design Power (TDP) of the processors, memory and storage.
 
 The equation used to model the energy consumption is:
-P[kwH] = (Power consumed by CPU or Pc Number of cores + Power consumed by Memory or Pr + Power consumed by GPU or Pg Number of GPUs)/1000
-	• CPU Utilization doesn’t scale linearly with power consumption, we will use the power curve as described in the [article](https://medium.com/teads-engineering/building-an-aws-ec2-carbon-emissions-dataset-3f0fd76c98ac)
-	• TDP of server used in Azure is [Intel Xeon Platinum 8380 Processor](https://www.intel.com/content/www/us/en/products/sku/212287/intel-xeon-platinum-8380-processor-60m-cache-2-30-ghz/specifications.html?wapkw=intel%20xeon%20platinum%208370c) for Graph DBs and [Intel Xeon Platinum 8270 Processor](https://www.intel.com/content/www/us/en/products/sku/192482/intel-xeon-platinum-8270-processor-35-75m-cache-2-70-ghz/specifications.html) for the APIs
-	• [From this article](https://www.crucial.com/support/articles-faq-memory/how-much-power-does-memory-use), it shows that RAM consumes 0.38kwh/GB. So a 32G of RAM allocated for each VM, would equate to 32 * 0.38 = 12.16 kwh
+ 
+`P[kwH] = (Power consumed by CPU or Pc Number of cores + Power consumed by Memory or Pr + Power consumed by GPU or Pg Number of GPUs)/1000`
+
+• CPU Utilization doesn’t scale linearly with power consumption, we will use the power curve as described in the [article](https://medium.com/teads-engineering/building-an-aws-ec2-carbon-emissions-dataset-3f0fd76c98ac)
+• TDP of server used in Azure is [Intel Xeon Platinum 8380 Processor](https://www.intel.com/content/www/us/en/products/sku/212287/intel-xeon-platinum-8380-processor-60m-cache-2-30-ghz/specifications.html?wapkw=intel%20xeon%20platinum%208370c) for Graph DBs and [Intel Xeon Platinum 8270 Processor](https://www.intel.com/content/www/us/en/products/sku/192482/intel-xeon-platinum-8270-processor-35-75m-cache-2-70-ghz/specifications.html) for the APIs
+• [From this article](https://www.crucial.com/support/articles-faq-memory/how-much-power-does-memory-use), it shows that RAM consumes 0.38kwh/GB. So a 32G of RAM allocated for each VM, would equate to 32 * 0.38 = 12.16 kwh
 
 #### Intensity was used by utilizing the Carbon Aware SDK and retrieving current emissions for each Azure region.
 
 #### Embodied Carbon (M)
 
-The equation to calculate M = TE * (TR/EL) * (RR/TR)
+The equation to calculate M: `M = TE * (TR/EL) * (RR/TR)`
+ 
 Where:
 	• TE = Total Embodied Emissions, the sum of LCA emissions for all hardware components associated with the application server.
 	• TR = Time Reserved, the length of time the hardware is reserved for use by the software.
@@ -57,20 +60,30 @@ Where:
 ### (Quantify) SCI Value Calculation
 
 #### TigerGraph DB
+
 Memory Allocation = 32G
 vCPU Allocation = 8
 CPU Utilization = 17.12
 Memory Utilization = 6.2
 
-E-CPU = ((270*.4) ) x 1) = 108 w / 1000 = 0.108 kwh	(TDP * coefficient, converted to kwh)
-E-Mem =  ((0.38 * 6.2) x 1) = 2.36 w / 1000 = 0.054 kwh	(power consumption per gig * gig memory utilized, converted to kwh)
-Total E = 0.110 kwh	0.108 + .0.054
+`E-CPU = ((270*.4) x 1) = 108 w / 1000 = 0.108 kwh`	(TDP * coefficient, converted to kwh)
+ 
+`E-Mem =  ((0.38 * 6.2) x 1) = 2.36 w / 1000 = 0.054 kwh`	(power consumption per gig * gig memory utilized, converted to kwh)
+ 
+`Total E = 0.110 kwh	0.108 + .0.054`
 
-I - 554g (East US & North Central) - Collected on 10/27/2022
+I = 554g (East US & North Central) - Collected on 10/27/2022
 
-M=1533.12 * (1/35040) * (2/64)= 0.0014kg, ~1.4 gCO2e	 ((total embodied coefficient * (1 hour/3 years of use) * (instance memory / platform Memory) )
-M=1533.12 * (1/35040) * (1/8) = 0.0054kg, 5.47gCO2e	((Total Embodied Coefficient * (1 hour/3 years of use) * (instance CPU/ platform CPU) )
-Total M = 6.87	1.4 + 5.47
+`M = 1533.12 * (1/35040) * (2/64)= 0.0014kg, ~1.4 gCO2e`
+
+(total embodied coefficient * (1 hour/3 years of use) * (instance memory / platform Memory) )
+ 
+`M=1533.12 * (1/35040) * (1/8) = 0.0054kg, 5.47gCO2e`	
+ 
+((Total Embodied Coefficient * (1 hour/4 years of use) * (instance CPU/ platform CPU) )
+Note that 4 years of use = 35040 hours (4 * 365 * 24 = 35040)
+
+`Total M = 6.87	1.4 + 5.47`
 
 > SCI Total for TigerGraph DB = (0.110 kwh * 554 gCO2e/KwH) + 6.87 gCO2e = 67.81 kgCO2e
 
@@ -80,20 +93,25 @@ Memory allocation = 1.75
 CPU Utilization = 25.0
 Memory Utilization = 70% 
 
-1.75G-1.22 = 0.53 (Memory allocated - Memory used) = what is available
-
-E-CPU = (205*.4) ) x 1 = 82 w / 1000 = 0.082 kwh	(converted number to kilowatts (TDP * coefficient)
-E-Mem =  (.38 * 1.22) x 1  = 0.4636 w / 1000 = .00046 kwh	(power consumption * memory utilized)
-Total E = 0.0824 kwh	0.082 + .00046
+`1.75G-1.22 = 0.53` (Memory allocated - Memory used) = what is available
+ 
+`E-CPU = (205*.4) ) x 1 = 82 w / 1000 = 0.082 kwh`	(converted number to kilowatts (TDP * coefficient))
+ 
+`E-Mem =  (.38 * 1.22) x 1  = 0.4636 w / 1000 = .00046 kwh`	(power consumption * memory utilized)
+ 
+`Total E = 0.082 + .00046 = 0.0824 kwh`
 
 I - 554g (East US & North Central) - Collected on 10/27/2022
 
-M=1216.62 * (1/35040) * (2/64)= 0.0012kg, 1.12 gCO2e	 ((total embodied coefficient * (1 hour/3 years of use) * (instance memory / platform memory) )
-M=1216.62 * (1/35040) * (1/8) =  0.0043  ~4.34 gCO2e	((total embodied coefficient * (1 hour/3 years of use) * (Instance CPU/ platform CPU) )
-Total M =5.46 gCO2e	CPU + Memory 1.12 + 4.34 
+`M = 1216.62 * (1/35040) * (2/64)= 0.0012kg, 1.12 gCO2e`	 
+(total embodied coefficient * (1 hour/4 years of use) * (instance memory / platform memory))
+
+`M=1216.62 * (1/35040) * (1/8) =  0.0043  ~4.34 gCO2e`	
+((total embodied coefficient * (1 hour/4 years of use) * (Instance CPU/ platform CPU) )
+
+`Total M = 1.12 + 4.34 = 5.46 gCO2e`
 
 > SCI Total TigerGraph API - (0.0824 kwh * 554 gCO2e/KwH) + 5.46 gCO2e = 51.10 gCO2e
-
 
 
 ### Total Tiger DB + API = 118.91	(67.81 + 51.10)
@@ -106,16 +124,19 @@ vCPU Utilized = 28.05
 Memory Utilized= 32G - 25.63 (Min Available Mem) = 6.3
 
 
-E-CPU = (270*.5) x 1) = 135 w / 1000 = 0.135 kwh	(converted number to kilowatts (TDP * Coefficient)
-E-Mem =  (.38 * 6.3) x 1 = 2.40 w / 1000 =0.024kwh	(power consumption * memory utilized)
-Total E=0.159 kwh	0.135 +0.024
+`E-CPU = (270*.5) x 1) = 135 w / 1000 = 0.135 kwh`	(converted number to kilowatts (TDP * Coefficient)
+`E-Mem =  (.38 * 6.3) x 1 = 2.40 w / 1000 =0.024kwh`	(power consumption * memory utilized)
+`Total E=0.159 kwh	0.135 +0.024`
 
 I - 554g (East US & North Central)
 
-M=1533.12 * (1/35040) * (2/64)=  Memory 0.0014, ~1.40  gCO2e  	((total embodied coefficient * (1 hour/3 years of use) * (instance memory / platform memory) )
-M=1533.12 * (1/35040) * (1/8) = CPU 0.0054kg, ~5.47 gCO2e	((total embodied coefficient * (1 hour/3 years of use) * (Instance CPU/ platform CPU) )
+`M = 1533.12 * (1/35040) * (2/64)=  Memory 0.0014, ~1.40  gCO2e`  	
+(total embodied coefficient * (1 hour/4 years of use) * (instance memory / platform memory) )
 
-Total M 6.87  gCO2e	CPU + memory 1.12 + 4.34 
+`M = 1533.12 * (1/35040) * (1/8) = CPU 0.0054kg, ~5.47 gCO2e`	
+((total embodied coefficient * (1 hour/4 years of use) * (Instance CPU/ platform CPU) )
+
+`Total M = 1.12 + 4.34  = 6.87  gCO2e` 
 
 
 > SCI = Total Neo4J DB = (0.159 kwh * 554 gCO2e/kwh) + 6.87 gCO2e = 94.95 gCO2e
@@ -128,15 +149,19 @@ Memory Utilization = 65%
 1.75 * 0.38 = 0.665 watts (Memory allocated * kwh Consumed)
 1.75G-1.13 = 0.62 (Memory allocated - Memory used) = what is available
 
-E-CPU = (205*.8) )x 1 = 164 w / 1000 = 0.164 kwh	(converted number to kilowatts (TDP * coefficient)
-E-Mem =  (0.38* 1.13) x 1= 43 kwh / 1000 = 1000 .00043 kwh	(power consumption * memory utilized)
-Total E = 0.1644 kgCO2e/kwh	0.164 + .00043
+`E-CPU = (205*.8) )x 1 = 164 w / 1000 = 0.164 kwh`	(converted number to kilowatts (TDP * coefficient)
+`E-Mem =  (0.38* 1.13) x 1= 43 kwh / 1000 = 1000 .00043 kwh`	(power consumption * memory utilized)
+`Total E = 0.164 + .00043 = 0.1644 kgCO2e/kwh`
 
 I - 554 gCO2e (East US & North Central)
 
-M=1216.62 * (1/35040) * (2/64)=  Memory 0.0011kg, ~1.12g  gCO2e	((total embodied coefficient * (1 hour/3 years of use) * (Instance CPU/ platform CPU) )
-M=1216.62 * (1/35040) * (1/8) = CPU 0.0043kg  ~4.34 gCO2e	((total embodied coefficient * (1 hour/3 years of use) * (Instance CPU/ platform CPU) )
-Total M  5.46 gCO2e	CPU + memory 
+`M = 1216.62 * (1/35040) * (2/64)=  Memory 0.0011kg, ~1.12g  gCO2e`	
+(total embodied coefficient * (1 hour/4 years of use) * (Instance CPU/ platform CPU) )
+
+`M = 1216.62 * (1/35040) * (1/8) = CPU 0.0043kg  ~4.34 gCO2e`	
+(total embodied coefficient * (1 hour/4 years of use) * (Instance CPU/ platform CPU) )
+
+`Total M = 5.46 gCO2e` 
 
 > SCI Total Neo4J API = (0.1644 kwh * 554 gCO2e/kwh) + 5.46 gCO2e = 96.5 gCO2e
 


### PR DESCRIPTION
Formatted equations to make them easier to read, and noticed text explanations assert 3 year lifespan, but equations use 35040 hours, which is 4 years - fixed in PR.