### PR TITLE
readme: actualize project name and site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 Follow the instructions in [CONFIGURE.md](CONFIGURE.md) to learn how to configure this template repository.
 
-# PROJECT-TITLE
+# SCI Guidance
 
-SCI Open Data
-
-This is a project run through the [Standards Working Group](https://standards.greensoftware.foundation/) in the [Green Software Foundation](https://greensoftware.foundation) and can be viewed through https://sci-data.greensoftware.foundation
+This is a project run through the [Standards Working Group](https://standards.greensoftware.foundation/) in the [Green Software Foundation](https://greensoftware.foundation) and can be viewed through https://sci-guide.greensoftware.foundation
 
 ## Copyright
 


### PR DESCRIPTION
An existing description is not entirely actual:
- There is no project name configured.
- Website link is dead (since link referred to the outdated URL).
