### PR TITLE
Clarify example networking metric is within a hyperscaler network

### DIFF
--- a/docs/E/NetworkEnergy.md
+++ b/docs/E/NetworkEnergy.md
@@ -14,4 +14,4 @@ There are 2 types of energy associated with the networking infrastructure.
 
 Calculating these values and multiplying them by the reference value of energy spent/GB will provide the usage emissions for networking infrastructure.
 
-For example, [we calculated the energy spent/GB](https://github.com/Green-Software-Foundation/sci-data/issues/13#issuecomment-1123962142) and came out with 0.001 KwH/GB.
+For example, [we calculated the energy spent/GB](https://github.com/Green-Software-Foundation/sci-data/issues/13#issuecomment-1123962142) within a hyperscaler network and came out with 0.001 KwH/GB.

--- a/docs/E/NetworkEnergy.md
+++ b/docs/E/NetworkEnergy.md
@@ -14,4 +14,4 @@ There are 2 types of energy associated with the networking infrastructure.
 
 Calculating these values and multiplying them by the reference value of energy spent/GB will provide the usage emissions for networking infrastructure.
 
-For example, [we calculated the energy spent/GB](https://github.com/Green-Software-Foundation/sci-data/issues/13#issuecomment-1123962142) within a hyperscaler network and came out with 0.001 KwH/GB.
+For example, [we calculated the energy spent/GB](https://github.com/Green-Software-Foundation/sci-data/issues/13#issuecomment-1123962142) within a hyperscaler network and came out with 0.001 kWh/GB.


### PR DESCRIPTION
As described [in the cited thread](https://github.com/Green-Software-Foundation/sci-guide/issues/13#issuecomment-1123962142), the 0.001 kWh/GB figure is an estimate for data transfer *within a hyperscaler network*. This critical piece of information is missing from the instruction page. Readers can assume 0.001 kWh/GB is the full end-user-to-server data transfer, which can be several orders of magnitude larger.

Also fix a typo in kWh unit.

This PR fixes #78.